### PR TITLE
fix for escaped quotes in attribute values

### DIFF
--- a/src/java/com/marklogic/ps/RecordLoader.java
+++ b/src/java/com/marklogic/ps/RecordLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c)2005-2010 Mark Logic Corporation
+ * Copyright (c)2005-2011 Mark Logic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ public class RecordLoader {
     private static final String SIMPLE_NAME = RecordLoader.class
             .getSimpleName();
 
-    public static final String VERSION = "2011-09-28.1";
+    public static final String VERSION = "2011-11-30.1";
 
     public static final String NAME = RecordLoader.class.getName();
 

--- a/src/java/com/marklogic/ps/Utilities.java
+++ b/src/java/com/marklogic/ps/Utilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c)2004-2010 Mark Logic Corporation
+ * Copyright (c)2004-2011 Mark Logic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,8 @@ public class Utilities {
 
     protected static Pattern[] patterns = new Pattern[] {
             Pattern.compile("&"), Pattern.compile("<"),
-            Pattern.compile(">") };
+            Pattern.compile(">"),
+            Pattern.compile("\"") };
 
     public static String escapeXml(String _in) {
         if (null == _in)
@@ -46,6 +47,12 @@ public class Utilities {
                 patterns[1].matcher(
                         patterns[0].matcher(_in).replaceAll("&amp;"))
                         .replaceAll("&lt;")).replaceAll("&gt;");
+    }
+
+    public static String escapeXml(String _in, boolean _attribute) {
+        if (!_attribute) return escapeXml(_in);
+
+        return patterns[3].matcher(escapeXml(_in)).replaceAll("&quot;");
     }
 
     public static String join(Collection<String> thisPath, String _delim) {

--- a/src/java/com/marklogic/recordloader/Producer.java
+++ b/src/java/com/marklogic/recordloader/Producer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2006-2009 Mark Logic Corporation. All rights reserved.
+ * Copyright (c) 2006-2011 Mark Logic Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -172,8 +172,9 @@ public class Producer extends InputStream {
                             + (null == aPrefix ? "" : (aPrefix + ":"))
                             + xpp.getAttributeName(i)
                             + "=\""
-                            + Utilities.escapeXml(xpp
-                                    .getAttributeValue(i)) + "\"";
+                            + Utilities.escapeXml(
+                                    xpp.getAttributeValue(i), true)
+                                    + "\"";
                 }
             }
             text += (isEmpty ? "/>" : ">");


### PR DESCRIPTION
I found that RecordLoader would choke on escaped quotes in attribute values. This is a corner-case of the "bug 249" fix in Producer.java. Test XML:

```
<TEST>
  <NUM>abc123</NUM>
  <DESC description="&quot;Brief Summary"></DESC>
</TEST>
```

Use `ID_NAME=NUM` and `RECORD_NAME=#DOCUMENT` to test this.
